### PR TITLE
Speed up

### DIFF
--- a/inst/include/cpp11/column_class.hpp
+++ b/inst/include/cpp11/column_class.hpp
@@ -5,15 +5,6 @@
 
 template <typename T>
 class Column_Scalar : public virtual Column {
-protected:
-  int default_val;
-  SEXP out;
-  int* out_data;
-public:
-  inline void add_default() {
-    *this->out_data = this->default_val;
-    ++this->out_data;
-  }
 };
 
 template <>

--- a/inst/include/cpp11/json_path.hpp
+++ b/inst/include/cpp11/json_path.hpp
@@ -41,6 +41,20 @@ public:
   }
 };
 
+template <>
+class JSON_Path_Element<std::string_view> : public virtual JSON_Path_Element_Base {
+private:
+  std::string_view key;
+public:
+  JSON_Path_Element<std::string_view>(const std::string_view & key) {
+    this->key = key;
+  }
+
+  const std::string to_path() {
+    return "/" + std::string(key);
+  }
+};
+
 class JSON_Path {
 private:
   std::vector<std::unique_ptr<JSON_Path_Element_Base>> path_elements;
@@ -53,6 +67,10 @@ public:
     path_elements.push_back(std::make_unique<JSON_Path_Element<std::string>>(key));
   }
 
+  void insert(const std::string_view key) {
+    path_elements.push_back(std::make_unique<JSON_Path_Element<std::string_view>>(key));
+  }
+
   void insert_dummy() {
     this->insert(-1);
   }
@@ -63,6 +81,10 @@ public:
 
   void replace(const std::string& key) {
     path_elements.back() = std::make_unique<JSON_Path_Element<std::string>>(key);
+  }
+
+  void replace(const std::string_view& key) {
+    path_elements.back() = std::make_unique<JSON_Path_Element<std::string_view>>(key);
   }
 
   void drop() {

--- a/inst/include/cpp11/json_path.hpp
+++ b/inst/include/cpp11/json_path.hpp
@@ -7,7 +7,7 @@ class JSON_Path_Element_Base {
 public:
   virtual ~JSON_Path_Element_Base() {};
 
-  virtual const std::string to_path() = 0;
+  virtual std::string to_path() const = 0;
 };
 
 template <typename T>
@@ -22,7 +22,7 @@ public:
     this->index = index;
   }
 
-  const std::string to_path() {
+  std::string to_path() const {
     return "[" + std::to_string(this->index) + "]";
   }
 };
@@ -36,7 +36,7 @@ public:
     this->key = key;
   }
 
-  const std::string to_path() {
+  std::string to_path() const {
     return "/" + key;
   }
 };
@@ -50,7 +50,7 @@ public:
     this->key = key;
   }
 
-  const std::string to_path() {
+  std::string to_path() const {
     return "/" + std::string(key);
   }
 };
@@ -91,7 +91,7 @@ public:
     path_elements.pop_back();
   }
 
-  const std::string path() {
+  std::string path() const {
     std::string out = "";
     for (auto & it : path_elements) {
       out += (*it).to_path();

--- a/inst/include/cpp11/parse.hpp
+++ b/inst/include/cpp11/parse.hpp
@@ -6,7 +6,7 @@
 
 using simdjson::ondemand::json_type;
 
-inline auto bad_json_type_message(simdjson::ondemand::value element, const std::string& expected, JSON_Path& path) {
+inline auto bad_json_type_message(simdjson::ondemand::value element, const std::string& expected, const JSON_Path& path) {
     return "Cannot convert a JSON " + json_type_to_string(element) + " to " + expected + " at path " + path.path();
 }
 
@@ -26,7 +26,7 @@ inline int parse_scalar_bool(simdjson::ondemand::value element, JSON_Path& path)
     }
 }
 
-inline int parse_scalar_int(simdjson::ondemand::value element, JSON_Path& path) {
+inline int parse_scalar_int(simdjson::ondemand::value element, const JSON_Path& path) {
     switch (element.type()) {
     case json_type::number:
         // TODO this is unsafe; add handling of big integers
@@ -40,7 +40,7 @@ inline int parse_scalar_int(simdjson::ondemand::value element, JSON_Path& path) 
     }
 }
 
-inline double parse_scalar_double(simdjson::ondemand::value element, JSON_Path& path) {
+inline double parse_scalar_double(simdjson::ondemand::value element, const JSON_Path& path) {
     switch (element.type()) {
     case json_type::number:
         return static_cast<double>(element);
@@ -53,7 +53,7 @@ inline double parse_scalar_double(simdjson::ondemand::value element, JSON_Path& 
     }
 }
 
-inline SEXPREC* parse_scalar_string(simdjson::ondemand::value element, JSON_Path& path) {
+inline SEXPREC* parse_scalar_string(simdjson::ondemand::value element, const JSON_Path& path) {
     switch (element.type()) {
     case json_type::string:
         return Rf_mkChar(std::string(std::string_view(element)).c_str());

--- a/inst/include/cpp11/parser_class.hpp
+++ b/inst/include/cpp11/parser_class.hpp
@@ -177,6 +177,7 @@ public:
 
         auto it = this->cols.find(key_v);
         if (it != cols.end()) {
+          path.replace(key_v);
           (*(*it).second).add_value(field.value(), path);
         }
       }

--- a/inst/include/cpp11/parser_class.hpp
+++ b/inst/include/cpp11/parser_class.hpp
@@ -136,21 +136,22 @@ public:
 
 class Parser_Dataframe : public virtual Parser{
 protected:
-  std::unordered_map<std::string, std::unique_ptr<Column>> cols;
-  std::unordered_map<std::string, bool> key_found;
+  std::unordered_map<std::string_view, std::unique_ptr<Column>> cols;
+  std::unordered_map<std::string_view, bool> key_found;
   std::vector<std::string> col_order;
+  std::vector<std::unique_ptr<std::string>> string_view_protection;
 
 public:
   Parser_Dataframe(std::unordered_map<std::string, std::unique_ptr<Column>>& cols,
-                   std::vector<std::string> col_order) {
+                   const std::vector<std::string> col_order) {
     for (auto & col : cols) {
-      this->cols.insert({col.first, std::move(col.second)});
-      this->key_found[col.first] = false;
+      string_view_protection.push_back(std::make_unique<std::string>(col.first));
+      // string_view_protection.push_back(std::move(std::make_unique<std::string>(col.first)));
+      this->cols.insert({*string_view_protection.back(), std::move(col.second)});
+      this->key_found[*string_view_protection.back()] = false;
     }
 
-    for (auto nm : col_order) {
-      this->col_order.push_back(nm);
-    }
+    this->col_order = col_order;
   };
 
   inline SEXP parse_json(simdjson::ondemand::value json, JSON_Path& path) {
@@ -171,11 +172,17 @@ public:
 
       path.insert_dummy();
       for (auto field : object) {
-        std::string key = safe_get_key(field);
-        path.replace(key);
-        if (this->cols.find(key) != cols.end()) {
-          (*this->cols[key]).add_value(field.value(), path);
-          this->key_found[key] = true;
+        std::string_view key_v;
+        auto error = field.unescaped_key().get(key_v);
+        if (error) {
+          // TODO when could this actually happen??
+          cpp11::stop("Something went wrong with the key");
+        }
+
+        if (this->cols.find(key_v) != cols.end()) {
+          path.replace(key_v);
+          (*this->cols[key_v]).add_value(field.value(), path);
+          this->key_found[key_v] = true;
         }
       }
       path.drop();
@@ -195,7 +202,9 @@ public:
     int i = 0;
     for (std::string col : col_order) {
       auto it = this->cols.find(col);
-      SET_VECTOR_ELT(out, i, (*(*it).second).get_value());
+      if (it != cols.end()) {
+        SET_VECTOR_ELT(out, i, (*(*it).second).get_value());
+      }
       i++;
     }
 

--- a/inst/include/cpp11/parser_class.hpp
+++ b/inst/include/cpp11/parser_class.hpp
@@ -179,9 +179,9 @@ public:
           cpp11::stop("Something went wrong with the key");
         }
 
-        if (this->cols.find(key_v) != cols.end()) {
-          path.replace(key_v);
-          (*this->cols[key_v]).add_value(field.value(), path);
+        auto it = this->cols.find(key_v);
+        if (it != cols.end()) {
+          (*(*it).second).add_value(field.value(), path);
           this->key_found[key_v] = true;
         }
       }

--- a/jsonparsetest/src/test-json_path.cpp
+++ b/jsonparsetest/src/test-json_path.cpp
@@ -6,7 +6,7 @@
 context("json_path") {
   test_that("can create a path") {
     auto path = JSON_Path();
-    path.insert("a");
+    path.insert(std::string_view("a"));
     expect_true(path.path() == "/a");
 
     path.insert(1);

--- a/jsonparsetest/src/test-parser-class.cpp
+++ b/jsonparsetest/src/test-parser-class.cpp
@@ -28,13 +28,13 @@ context("Parser_Scalar") {
   auto path = JSON_Path();
 
   test_that("can parse a scalar bool") {
-    path.insert("lgl_true");
+    path.insert(std::string_view("lgl_true"));
     expect_true(parser_lgl.parse_json(doc["lgl_true"].value(), path) == as_sexp(true));
 
-    path.replace("lgl_false");
+    path.replace(std::string_view("lgl_false"));
     expect_true(parser_lgl.parse_json(doc["lgl_false"].value(), path) == as_sexp(false));
 
-    path.replace("lgl_null");
+    path.replace(std::string_view("lgl_null"));
     expect_true(parser_lgl.parse_json(doc["lgl_null"].value(), path) == Rf_ScalarLogical(NA_LOGICAL));
   }
 


### PR DESCRIPTION
* use `std::string_view`
  * add a private member value `std::vector<std::unique_ptr<std::string>> string_view_protection;`
  * map key must point to the corresponding value in `string_view_protection`
* only search once for a key instead of twice
* remove `key_found` map by storing the info in the Column class

Without the inefficient path it is now faster than `RcppSimdJson`
```r
# A tibble: 2 × 13
  expression        min   median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time result memory 
  <bch:expr>   <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl> <int> <dbl>   <bch:tm> <list> <list> 
1 jsonparse      3.42ms   3.84ms      253.     238KB     0      100     0      395ms <NULL> <Rprof…
2 RcppSimdJson   4.13ms    4.8ms      204.    3.59MB     2.06    99     1      485ms <NULL> <Rprof…
```